### PR TITLE
SAK-26078 - Add support to retail keySet behavior

### DIFF
--- a/src/main/java/org/azeckoski/reflectutils/map/ConcurrentOrderedMap.java
+++ b/src/main/java/org/azeckoski/reflectutils/map/ConcurrentOrderedMap.java
@@ -186,6 +186,20 @@ public class ConcurrentOrderedMap<K, V> extends ConcurrentHashMap<K, V> implemen
     transient Set<Map.Entry<K,V>> entrySet;
     transient Collection<V> values;
     
+    /*
+    @Override
+    public KeySetView <K,V> keySet() {
+        //Don't use this method?
+        return null;
+    }
+    */
+
+    //Do not use keySet, you need to use this one
+    public Set<K> legacyKeySet() {
+        Set<K> ks = keySet;
+        return (ks != null) ? ks : (keySet = new KeySet());
+    }
+
     @Override
     public Collection<V> values() {
         Collection<V> vs = values;

--- a/src/test/java/org/azeckoski/reflectutils/map/ConcurrentOrderedMapTest.java
+++ b/src/test/java/org/azeckoski/reflectutils/map/ConcurrentOrderedMapTest.java
@@ -251,7 +251,7 @@ public class ConcurrentOrderedMapTest extends ArrayOrderedMapTest {
 
 
     public void testKeySet() {
-        Set<String> keys = m1.keySet();
+        Set<String> keys = m1.legacyKeySet();
         assertEquals(3, keys.size());
         Iterator<String> it = keys.iterator();
         assertTrue( it.hasNext() );


### PR DESCRIPTION
More changes for a test case failing. So removing the keySet in #1 was only half of the problem. It still didn't correctly work and pass the test if anyone used it.

The problem is that in Java 8 the keySet changed to
public KeySetView <K,V> keySet() 
from
public Set<K> keySet()

It seems like the only way we could have a version compatible with both 7 and 8 was to introduce a new method (I called it legacyKeySet) which would return the concurrentOrderedMap from KeySet. The test passes with this, and nothing *in* the code uses it. Anything calling keySet directly is going to fail though.

So what do we do about that? 
- Do nothing and keySet will always return the wrong value for this class
- Override it either returning null or an empty key set, maybe log an error not to use it. Then it's obvious to use something else if someone does use it. That would still make it incompatible with either Java 7 or Java 8
- Implement it so it returns the correct value in Java 8 (More work)