### PR TITLE
Lockdown the surefire plugin version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.18.1</version>
                 <configuration>
                     <excludes>
                         <exclude>**/Test*.java</exclude>


### PR DESCRIPTION
Maven was warning about the plugin version not being defined so lock it down.